### PR TITLE
fix respawn bug on dedicated server

### DIFF
--- a/addons/CBRN_contamination/cfgVehicles.hpp
+++ b/addons/CBRN_contamination/cfgVehicles.hpp
@@ -6,7 +6,7 @@ class CfgVehicles {
 		{
 			class CBRN_Contamination
 			{
-				respawn = "(_this select 0) setVariable ['CBRN_contaminationLevel', 0];(_this select 0) setVariable ['CBRN_chemicalDamage', 0];(_this select 0) setVariable ['CBRN_chemicalDamageHandler', -1];";
+				respawn = "(_this select 0) setVariable ['CBRN_contaminationLevel', 0, 2];(_this select 0) setVariable ['CBRN_chemicalDamage', 0, 2];(_this select 0) setVariable ['CBRN_chemicalDamageHandler', -1, 2];";
 			};
 		};
 	};


### PR DESCRIPTION
fix respawn bug on dedicated server by making respawn EventHandler set variables on server instead of local machine. 