### PR TITLE
fix ace grande handler

### DIFF
--- a/addons/CBRN_contamination/functions/fn_addChemicalDamageHandler.sqf
+++ b/addons/CBRN_contamination/functions/fn_addChemicalDamageHandler.sqf
@@ -94,6 +94,7 @@ if ((_this getVariable ["CBRN_chemicalDamageHandler", -1]) == -1) then {
 		//Since we have no contamination or damage, we can remove the PFH and undo side effects
 		} else {
 			_handle call CBA_fnc_removePerFrameHandler;
+			_unit setVariable ['CBRN_chemicalDamageHandler', -1, 2];
 			
 			//Let them do things again (If we took it away when ACE was enabled)
 			//We know this is fine because we are at a point where contamination and damage are both 0

--- a/addons/CBRN_contamination/functions/fn_addChemicalDamageHandler.sqf
+++ b/addons/CBRN_contamination/functions/fn_addChemicalDamageHandler.sqf
@@ -94,7 +94,7 @@ if ((_this getVariable ["CBRN_chemicalDamageHandler", -1]) == -1) then {
 		//Since we have no contamination or damage, we can remove the PFH and undo side effects
 		} else {
 			_handle call CBA_fnc_removePerFrameHandler;
-			_unit setVariable ['CBRN_chemicalDamageHandler', -1, 2];
+			_unit setVariable ['CBRN_chemicalDamageHandler', -1];
 			
 			//Let them do things again (If we took it away when ACE was enabled)
 			//We know this is fine because we are at a point where contamination and damage are both 0

--- a/addons/CBRN_data/cfgFunctions.hpp
+++ b/addons/CBRN_data/cfgFunctions.hpp
@@ -10,6 +10,7 @@ class CfgFunctions
 			class getItemConfigValue {};
 			class throwWarning {};
 			class initializeCBRN {preInit = 1};
+			class initializeGrenades {postInit = 1};
 			class registerKeybinds {postInit = 1};
 			class registerSettings {postInit = 1};
 		};

--- a/addons/CBRN_data/functions/fn_initializeGrenades.sqf
+++ b/addons/CBRN_data/functions/fn_initializeGrenades.sqf
@@ -1,0 +1,18 @@
+/*
+	Description:
+		This function will add handlers for grenades if ace is loaded
+	
+	Remark(s):
+		This function should not be called, it is executed automatically
+
+	Parameter(s):
+		None
+
+	Returns:
+		Nothing
+*/
+if (isServer && CBRN_set_useACECommon) then {
+	['ace_firedPlayer', {_this call CBRN_fnc_handleGrenades}] call CBA_fnc_addEventHandler;
+	['ace_firedPlayerNonLocal', {_this call CBRN_fnc_handleGrenades}] call CBA_fnc_addEventHandler;
+	['ace_firedNonPlayer', {_this call CBRN_fnc_handleGrenades}] call CBA_fnc_addEventHandler;
+};

--- a/addons/CBRN_gear/cfgVehicles.hpp
+++ b/addons/CBRN_gear/cfgVehicles.hpp
@@ -8,7 +8,6 @@ class CfgVehicles {
 		{
 			class CBRN_Gear
 			{
-				init = "if (CBRN_set_useACECommon) then {_nil = (['ace_firedPlayer', {_this remoteExecCall ['CBRN_fnc_handleGrenades', 2]}] call CBA_fnc_addEventHandler)};";
 				respawn = "(_this select 0) addItem ((_this select 0) getVariable ['CBRN_respawnMask', ''])";
 				fired = "if (!CBRN_set_useACECommon) then {_this remoteExecCall ['CBRN_fnc_handleGrenades', 2]};";
 			};


### PR DESCRIPTION
Thy way grenades are handled currently cause some bugs, every time a unit is spawned all client add a new grenade handler, this is why CBRN grandes make the game lag, every time someone throw a grenade the function `CBRN_fnc_handleGrenades` is executed multiple time so it create multiple smoke effect and it might also be causing this : [https://forums.bohemia.net/forums/topic/220325-gun-keeps-randomly-firing/](https://forums.bohemia.net/forums/topic/220325-gun-keeps-randomly-firing/).

This PR will remove the current `ace_firedPlayer` event handler and only add it once at mission start on the server. 