### PR TITLE
Rename fake claymore with CBRN_ tag

### DIFF
--- a/addons/CBRN_gear/cfgAmmo.hpp
+++ b/addons/CBRN_gear/cfgAmmo.hpp
@@ -46,7 +46,7 @@ class cfgAmmo
 	class CBRN_IEDUrbanSmall_Type2_Range_Ammo: CBRN_IEDUrbanSmall_Type2_Remote_Ammo{mineTrigger = "RangeTriggerShort";};
 	
 	class ClaymoreDirectionalMine_Remote_Ammo_Scripted;
-	class ClaymoreDirectionalMine_Remote_Ammo_Scripted_Fake: ClaymoreDirectionalMine_Remote_Ammo_Scripted
+	class CBRN_ClaymoreDirectionalMine_Remote_Ammo_Scripted_Fake: ClaymoreDirectionalMine_Remote_Ammo_Scripted
 	{
 		hit = 0;
 		indirectHit = 0;

--- a/addons/CBRN_gear/functions/fn_handleProjectile.sqf
+++ b/addons/CBRN_gear/functions/fn_handleProjectile.sqf
@@ -45,7 +45,7 @@ private _chemLifeTime = [_ammoClass, "CBRN_lifetime", 30] call BIS_fnc_returnCon
 		if ((((getPos _projectile) # 2) <= _heightOfBurst) && (((velocity _projectile) # 2) < 0)) then {
 		
 			//Fuck the real projectile, get that sweet claymore boom
-			private _det = "ClaymoreDirectionalMine_Remote_Ammo_Scripted_Fake" createVehicle [0,0,0];
+			private _det = "CBRN_ClaymoreDirectionalMine_Remote_Ammo_Scripted_Fake" createVehicle [0,0,0];
 			_det setPos getPos _projectile;
 			_det setDamage 1;
 			


### PR DESCRIPTION
As @Drofseh said the fake calymore must be given a `CBRN_` tag.